### PR TITLE
Init-Script für PostgreSQL migriert in docker-entrypoint-initdb.d

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,4 +20,4 @@ EXPOSE 3000
 
 # Startkommando für die Anwendung definieren
 # shell command instead of exec form
-CMD sh -c "npm run initdb && npm start"
+CMD sh -c "npm start"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       backend:
         condition: service_healthy
-      
+
   backend:
     build:
       context: ./backend
@@ -37,6 +37,8 @@ services:
     image: postgres:17-alpine
     volumes:
       - db_data:/var/lib/postgresql/data
+      - ./initdb:/docker-entrypoint-initdb.d:ro
+
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -50,4 +52,3 @@ services:
       retries: 5
 volumes:
   db_data:
-  backend_data:

--- a/initdb/initdb.sql
+++ b/initdb/initdb.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS notes (
+  id SERIAL PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  content TEXT NOT NULL,
+  is_completed BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO notes (title, content, is_completed) VALUES
+('Test Note 1', 'This is a test note.', false),
+('Test Note 2', 'This is another test note.', true),
+('Test Note 3', 'This is yet another test note.', false)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Hi Stephi 👋

ich habe das bisherige npm run initdb entfernt und die SQL-Initialisierung sauber in die Postgres-Bootstrapping-Logik integriert.
Das passiert jetzt über das Verzeichnis /docker-entrypoint-initdb.d, das von offiziellen Postgres-Images beim ersten Start automatisch verarbeitet wird.

**Was wurde geändert?**
Neues Verzeichnis initdb/ mit einem init.sql, das automatisch beim Container-Start ausgeführt wird

Anpassung docker-compose.yml: initdb/ wird schreibgeschützt in den Datenbank-Container gemountet

CMD im backend-Dockerfile bereinigt → npm start reicht jetzt aus

**Vorteile**
Kein künstlicher Start-Delay mehr durch npm run initdb

Die Datenbank ist sofort einsatzbereit, sobald der Container hochkommt

Weniger Fehleranfälligkeit bei Start-Abfolgen (z. B. wenn DB zu spät erreichbar war)

Besser wartbare Trennung zwischen Anwendung und Infrastruktur

**Hinweis für Dev-Umgebung**
Da Init-Skripte nur beim ersten Start ausgeführt werden, muss man bei Änderungen im SQL ggf. das Volume zurücksetzen:

`docker-compose down -v`

Danach wird init.sql wie gewünscht erneut angewendet.